### PR TITLE
Allow upwards flexible versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "url": "https://github.com/Laiff/react-font-awesome/issues"
   },
   "peerDependencies": {
-    "react": "~0.11.2"
+    "react": ">=0.11.2"
   }
 }


### PR DESCRIPTION
This allows use with newer React versions. Quick spin with React 0.12.2 didn't show any problems.

Fixes #2 
